### PR TITLE
Potential fix for code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/lib/system-font.js
+++ b/lib/system-font.js
@@ -155,9 +155,13 @@ SystemFont.prototype.install = function(remoteFile, fileName, callback) {
 					});
 				}
 				else {
-					child_process.exec('cscript.exe ' + path.join(__dirname, 'windows', 'installFont.js') + ' ' + tmpPath, function(err, stdout, stderr){
-						callback(err, 'Font System Folder with cscript.');
-					})
+					child_process.execFile(
+						'cscript.exe',
+						[path.join(__dirname, 'windows', 'installFont.js'), tmpPath],
+						function(err, stdout, stderr) {
+							callback(err, 'Font System Folder with cscript.');
+						}
+					);
 				}
 			})	
 			break;


### PR DESCRIPTION
Potential fix for [https://github.com/tinsever/google-font-cli/security/code-scanning/1](https://github.com/tinsever/google-font-cli/security/code-scanning/1)

In general, the problem should be fixed by avoiding construction of a full shell command string that is executed through a shell. Instead, call the executable directly (`cscript.exe`) and pass the script path and `tmpPath` as separate arguments using `child_process.execFile` (or `spawn`). This prevents any special characters in the paths from being interpreted by a shell and ensures they are treated purely as arguments.

For this specific code, the best fix without changing functional behavior is:

- Replace the `child_process.exec` call on line 158 with `child_process.execFile`.
- Pass `'cscript.exe'` as the command, and provide an argument array `[path.join(__dirname, 'windows', 'installFont.js'), tmpPath]` instead of concatenating them into a single string.
- Keep the existing callback and its behavior unchanged.

The changes are localized to `lib/system-font.js` inside the `else` block for `majorVer < 6`. No new methods or external libraries are required, and existing imports already include `child_process` and `path`, so no import changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
