### PR TITLE
feat: modernize codebase with async/await and updated dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ node_modules
 test/
 
 .DS_Store
+*.zip
+*.tar.gz

--- a/cli.js
+++ b/cli.js
@@ -2,13 +2,14 @@
 
 "use strict";
 
-const program = require("commander");
+const { Command } = require("commander");
 const pc = require("picocolors");
 const ncp = require("copy-paste-win32fix");
 const GoogleFontList = require("./lib/google-font-list");
 const pjson = require("./package.json");
 
 const fontList = new GoogleFontList();
+const program = new Command();
 
 /**
  * Helper to wrap fontList initialization in a Promise

--- a/lib/google-font-list.js
+++ b/lib/google-font-list.js
@@ -2,7 +2,6 @@
 
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
-var async = require('async');
 var Request = require('./request');
 var googleFont = require('./google-font');
 
@@ -54,15 +53,11 @@ GoogleFontList.prototype.parseRawData = function(rawData) {
 
 GoogleFontList.prototype.populate = function(list){
 	var self = this;
-	async.each(list,
-		function(fontData, cb){
-			self.data.push(new googleFont(fontData));
-			cb();
-		}, function(err){
-			if (err)
-				self.emit('error', err);
-			self.emit('success', self);
-		})
+	list.forEach(function(fontData){
+		self.data.push(new googleFont(fontData));
+	});
+	self.loaded = true;
+	self.emit('success', self);
 }
 
 GoogleFontList.prototype.clone = function(){
@@ -74,24 +69,21 @@ GoogleFontList.prototype.clone = function(){
 GoogleFontList.prototype.searchFont = function(term, field, callback) {
 	var self = this;
 	var searchTerms = term.trim().length > 0 ? term.toLowerCase().split(' ') : [];
-	async.filter(
-		self.data,
-		function(el, cb) {
-			var found = searchTerms.length > 0 ? true : false;
-			searchTerms.forEach(function(subTerm){
-				var val = el[field] || '';
-				found = found && (val.toLowerCase().indexOf(subTerm) !== -1);
-			})
-			cb(found);
-		},
-		function(result) {
-			var fontList = self.clone();
-			fontList.data = result;
-			fontList._filterField = field;
-			fontList._filterTerm = term;
-			callback(null, fontList);
-		}
-	)
+	
+	const result = self.data.filter(function(el) {
+		var found = searchTerms.length > 0 ? true : false;
+		searchTerms.forEach(function(subTerm){
+			var val = el[field] || '';
+			found = found && (val.toLowerCase().indexOf(subTerm) !== -1);
+		});
+		return found;
+	});
+	
+	var fontList = self.clone();
+	fontList.data = result;
+	fontList._filterField = field;
+	fontList._filterTerm = term;
+	callback(null, fontList);
 };
 
 GoogleFontList.prototype.searchFontByName = function(term, callback) {
@@ -105,20 +97,17 @@ GoogleFontList.prototype.searchFontByType = function(term, callback) {
 GoogleFontList.prototype.getFont = function(term, field, callback) {
 	var self = this;
 	var searchTerms = term.trim().toLowerCase();
-	async.filter(
-		self.data,
-		function(el, cb) {
-			var val = el[field] || '';
-			cb( val.toLowerCase() === searchTerms );
-		},
-		function(result) {
-			var fontList = self.clone();
-			fontList.data = result;
-			fontList._filterField = field;
-			fontList._filterTerm = term;
-			callback(null, fontList);
-		}
-	)
+	
+	const result = self.data.filter(function(el) {
+		var val = el[field] || '';
+		return val.toLowerCase() === searchTerms;
+	});
+	
+	var fontList = self.clone();
+	fontList.data = result;
+	fontList._filterField = field;
+	fontList._filterTerm = term;
+	callback(null, fontList);
 }
 
 GoogleFontList.prototype.getFontByName = function(term, callback) {
@@ -139,10 +128,10 @@ GoogleFontList.prototype.isSingle = function(){
 
 GoogleFontList.prototype.forEachFont = function(fn, callback) {
 	var self = this;
-	async.forEachOf(this.data, function(el, index, cb){
+	this.data.forEach(function(el, index){
 		fn.call(self, el, index);
-		cb();
-	}, callback);
+	});
+	if (callback) callback();
 }
 
 module.exports = GoogleFontList;

--- a/lib/google-font.js
+++ b/lib/google-font.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var util = require('util');
-var async = require('async');
 var pascalCase = require('pascal-case');
 var systemFont = require('./system-font');
 var noop = require('./noop');
@@ -43,65 +42,85 @@ googleFont.prototype._getFileMap = function(format, callback) {
 	}
 	format = format || 'ttf';
 	
-	var self = this;
-	var options = {
+	// If no callback provided, return a promise
+	if (!callback) {
+		return this._getFileMapAsync(format);
+	}
+	
+	// Callback-based for backward compatibility
+	this._getFileMapAsync(format).then(
+		result => callback(null, result),
+		err => callback(err)
+	);
+};
+
+googleFont.prototype._getFileMapAsync = async function(format) {
+	format = format || 'ttf';
+	const options = {
 		headers: { 'User-Agent': 'google-font-installer-tin' }
 	};
 
-	https.get(this.apiUrl, options, function(res) {
-		if (res.statusCode !== 200) {
-			return callback(new Error('GWFH API returned ' + res.statusCode + ' for ' + self.getFamily()));
-		}
-
-		var data = '';
-		res.on('data', function(chunk) { data += chunk; });
-		res.on('end', function() {
-			try {
-				var json = JSON.parse(data);
-				var files = {};
-				
-				json.variants.forEach(function(v) {
-					// Map variants to IDs based on requested format
-					if (format === 'woff2' && v.woff2) {
-						files[v.id] = v.woff2;
-					} else if (format === 'ttf' && v.ttf) {
-						files[v.id] = v.ttf;
-					}
-				});
-				callback(null, files);
-			} catch (e) {
-				callback(new Error('Failed to parse GWFH JSON response'));
+	return new Promise((resolve, reject) => {
+		https.get(this.apiUrl, options, (res) => {
+			if (res.statusCode !== 200) {
+				return reject(new Error('GWFH API returned ' + res.statusCode + ' for ' + this.getFamily()));
 			}
-		});
-	}).on('error', callback);
+
+			let data = '';
+			res.on('data', (chunk) => { data += chunk; });
+			res.on('end', () => {
+				try {
+					const json = JSON.parse(data);
+					const files = {};
+					
+					json.variants.forEach((v) => {
+						// Map variants to IDs based on requested format
+						if (format === 'woff2' && v.woff2) {
+							files[v.id] = v.woff2;
+						} else if (format === 'ttf' && v.ttf) {
+							files[v.id] = v.ttf;
+						}
+					});
+					resolve(files);
+				} catch (e) {
+					reject(new Error('Failed to parse GWFH JSON response'));
+				}
+			});
+		}).on('error', reject);
+	});
 };
 
 googleFont.prototype.install = function(variants, callback) {
-	var self = this;
 	callback = callback || noop;
+	
+	this.installAsync(variants).then(
+		result => callback(null, result),
+		err => callback(err)
+	);
+};
 
-	this._getFileMap(function(err, fileList) {
-		if (err) return callback(err);
-		
-		var requested = (variants && variants.length) ? variants : Object.keys(fileList);
-		var resultList = [];
-		
-		async.eachSeries(requested, function(v, next) {
-			var norm = self._normalizeVariant(v);
-			var url = fileList[norm];
+googleFont.prototype.installAsync = async function(variants) {
+	const fileList = await this._getFileMapAsync('ttf');
+	const requested = (variants && variants.length) ? variants : Object.keys(fileList);
+	const resultList = [];
+	
+	for (const v of requested) {
+		const norm = this._normalizeVariant(v);
+		const url = fileList[norm];
 
-			if (url) {
-				systemFont.install(url, self._fileName + '-' + norm, function(err, path) {
-					if (path) resultList.push({ family: self.getFamily(), variant: norm, path: path });
-					next(err);
-				});
-			} else {
-				next();
+		if (url) {
+			try {
+				const path = await systemFont.install(url, this._fileName + '-' + norm);
+				if (path) {
+					resultList.push({ family: this.getFamily(), variant: norm, path: path });
+				}
+			} catch (err) {
+				throw err;
 			}
-		}, function(err) {
-			callback(err, resultList);
-		});
-	});
+		}
+	}
+	
+	return resultList;
 };
 
 googleFont.prototype.saveAt = function(variants, destFolder, format, callback) {
@@ -110,30 +129,37 @@ googleFont.prototype.saveAt = function(variants, destFolder, format, callback) {
 		callback = format;
 		format = 'ttf'; // default format
 	}
-	var self = this;
 	callback = callback || noop;
 
-	this._getFileMap(format, function(err, fileList) {
-		if (err) return callback(err);
-		var requested = (variants && variants.length) ? variants : Object.keys(fileList);
-		var resultList = [];
+	this.saveAtAsync(variants, destFolder, format).then(
+		result => callback(null, result),
+		err => callback(err)
+	);
+};
 
-		async.eachSeries(requested, function(v, next) {
-			var norm = self._normalizeVariant(v);
-			var url = fileList[norm];
+googleFont.prototype.saveAtAsync = async function(variants, destFolder, format) {
+	format = format || 'ttf';
+	const fileList = await this._getFileMapAsync(format);
+	const requested = (variants && variants.length) ? variants : Object.keys(fileList);
+	const resultList = [];
 
-			if (url) {
-				systemFont.saveAt(url, destFolder, self._fileName + '-' + norm, function(err, path) {
-					if (path) resultList.push({ family: self.getFamily(), variant: norm, path: path });
-					next(err);
-				});
-			} else {
-				next();
+	for (const v of requested) {
+		const norm = this._normalizeVariant(v);
+		const url = fileList[norm];
+
+		if (url) {
+			try {
+				const path = await systemFont.saveAt(url, destFolder, this._fileName + '-' + norm);
+				if (path) {
+					resultList.push({ family: this.getFamily(), variant: norm, path: path });
+				}
+			} catch (err) {
+				throw err;
 			}
-		}, function(err) {
-			callback(err, resultList);
-		});
-	});
+		}
+	}
+	
+	return resultList;
 };
 
 googleFont.prototype._normalizeVariant = function(variant) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -77,15 +77,13 @@ Request.prototype.handleResponse = function(res, originalUri) {
 			self.write(chunk);
 			chunks.push(chunk);
 		})
-		res.on('end', function(){
+		res.on('end', async function(){
 			var fullBuffer = Buffer.concat(chunks);
 			var message = fullBuffer.toString('utf8');
 			
 			try {
-				var fileType = require('file-type');
-				if (typeof fileType === 'function') {
-					self._mimeType = fileType(fullBuffer);
-				}
+				const { fileTypeFromBuffer } = await import('file-type');
+				self._mimeType = await fileTypeFromBuffer(fullBuffer);
 			} catch(e) {}
 
 			self.emit('success', message);

--- a/lib/system-font.js
+++ b/lib/system-font.js
@@ -3,9 +3,10 @@
 var util = require('util');
 var path = require('path');
 var os = require('os');
-var fs = require('fs');
+var fs = require('fs').promises;
+var fsSync = require('fs');
 var child_process = require('child_process');
-var mv = require('mv');
+var { exec } = require('child_process');
 var Request = require('./request');
 
 const platform = os.platform();
@@ -18,162 +19,136 @@ if (platform === 'win32') {
 
 function SystemFont() {}
 
-SystemFont.prototype._saveTmp = function(remoteFile, fileName, callback) {
+SystemFont.prototype._saveTmp = async function(remoteFile, fileName) {
 	if (!remoteFile) {
-		callback(new Error('Nothing to download'), null);
-		return;
+		throw new Error('Nothing to download');
 	}
-	var self = this;
-	this._checkDestFolder(tmp_folder, function(err, folder){
-		if (err) {
-			callback(err);
-			return;
-		}
-		var remoteExt = path.parse(remoteFile).ext;
-		var filePath = path.join(folder, fileName + remoteExt);
-		var localFile = fs.createWriteStream(filePath);
-		var download = new Request(remoteFile);
-		download.on('error', function(e){
-			callback(e, null);
-		})
-		.pipe(localFile)
-		.on('finish', function(){
-			var mimeType = download.getMimeType();
-			var ext = path.parse(filePath).ext.toLowerCase();
-			
-			// Check if the downloaded file is a valid font based on MIME type or file extension
-			var isValidFont = (mimeType && (mimeType.mime === 'application/font-sfnt' || mimeType.mime === 'font/woff2')) || 
-							  (ext === '.ttf' || ext === '.woff2');
-			
-			if (isValidFont) {
-				callback(null, filePath);
-			} else {
-				fs.unlink(filePath, function(e){
-					callback(new Error('Downloaded file is corrupted'), null);
-				})
-			}
-		})
-		.on('error', function(e){
-			callback(e, null);
-		})
+	
+	const folder = await this._checkDestFolder(tmp_folder);
+	const remoteExt = path.parse(remoteFile).ext;
+	const filePath = path.join(folder, fileName + remoteExt);
+	const localFile = fsSync.createWriteStream(filePath);
+	const download = new Request(remoteFile);
+	
+	return new Promise((resolve, reject) => {
+		download.on('error', reject)
+			.pipe(localFile)
+			.on('finish', async () => {
+				const mimeType = download.getMimeType();
+				const ext = path.parse(filePath).ext.toLowerCase();
+				
+				// Check if the downloaded file is a valid font based on MIME type or file extension
+				const isValidFont = (mimeType && (mimeType.mime === 'application/font-sfnt' || mimeType.mime === 'font/woff2')) || 
+								  (ext === '.ttf' || ext === '.woff2');
+				
+				if (isValidFont) {
+					resolve(filePath);
+				} else {
+					try {
+						await fs.unlink(filePath);
+					} catch (e) {}
+					reject(new Error('Downloaded file is corrupted'));
+				}
+			})
+			.on('error', reject);
 	});
-}
+};
 
-SystemFont.prototype._move = function(oldPath, destFolder, callback) {
-	this._checkDestFolder(destFolder, function(err, folder){
-		if (err) {
-			callback(err);
-			return;
-		}
-		var fileName = path.basename(oldPath).trim() || 'font.ttf';
-		var newPath =  path.join(folder, fileName);
-		mv(oldPath, newPath, function(err){
-			if (err) {
-				callback(new Error('Something went wrong writing the file.'), null);
-				return;
-			}
-			callback(null, newPath);
-		})
-	})
-}
+SystemFont.prototype._move = async function(oldPath, destFolder) {
+	const folder = await this._checkDestFolder(destFolder);
+	const fileName = path.basename(oldPath).trim() || 'font.ttf';
+	const newPath = path.join(folder, fileName);
+	
+	try {
+		await fs.rename(oldPath, newPath);
+		return newPath;
+	} catch (err) {
+		throw new Error('Something went wrong writing the file.');
+	}
+};
 
-SystemFont.prototype._checkDestFolder = function(destFolder, callback){
-	var self = this;
+SystemFont.prototype._checkDestFolder = async function(destFolder) {
 	if (destFolder === null || destFolder === undefined || !destFolder) {
 		destFolder = process.cwd() || os.homedir();
 	} else if (typeof destFolder !== 'string') {
 		throw new Error('Destination folder for font must be a string');
 	}
-	var absFolder = path.resolve(destFolder);
-	this._isFolderOk(absFolder, function(err){
-		if (err) {
-			callback(err);
-			return;
-		}
-		callback(null, absFolder);
-	})
-}
-
-SystemFont.prototype._isFolderOk = function(folder, callback) {
-	fs.mkdir(folder, function(err) {
-        // If the directory can't be created because it exists, we're good!
-		if (err && err.code !== 'EEXIST') {
-			callback('Error while creating folder ' + folder + ': ' + err);
-			return;
-		}
-		callback(null);
-	});
+	const absFolder = path.resolve(destFolder);
+	await this._isFolderOk(absFolder);
+	return absFolder;
 };
 
-SystemFont.prototype.saveAt = function(remoteFile, destFolder, fileName, callback) {
-	var self = this;
-	self._saveTmp(remoteFile, fileName, function(err, tmpPath){
-		if (err) {
-			callback(err, null);
-			return;
+SystemFont.prototype._isFolderOk = async function(folder) {
+	try {
+		await fs.mkdir(folder, { recursive: true });
+	} catch (err) {
+		if (err.code !== 'EEXIST') {
+			throw new Error('Error while creating folder ' + folder + ': ' + err);
 		}
-		self._move(tmpPath, destFolder, callback);
-	})
-}
-
-SystemFont.prototype.saveHere = function(remoteFile, fileName, callback) {
-	this.saveAt(remoteFile, false, fileName, callback);
+	}
 };
 
-SystemFont.prototype.install = function(remoteFile, fileName, callback) {
+SystemFont.prototype.saveAt = async function(remoteFile, destFolder, fileName) {
+	const tmpPath = await this._saveTmp(remoteFile, fileName);
+	return await this._move(tmpPath, destFolder);
+};
+
+SystemFont.prototype.saveHere = async function(remoteFile, fileName) {
+	return await this.saveAt(remoteFile, false, fileName);
+};
+
+SystemFont.prototype.install = async function(remoteFile, fileName) {
 	switch (platform) {
 		case 'linux':
-			var destFolder = path.join(os.homedir(), '.fonts/');
-			this.saveAt(remoteFile, destFolder, fileName, callback);
-			break;
+			const linuxDestFolder = path.join(os.homedir(), '.fonts/');
+			return await this.saveAt(remoteFile, linuxDestFolder, fileName);
+			
 		case 'darwin':
-			var destFolder = path.join(os.homedir(), 'Library', 'Fonts/');
-			this.saveAt(remoteFile, destFolder, fileName, callback);
-			break;
+			const darwinDestFolder = path.join(os.homedir(), 'Library', 'Fonts/');
+			return await this.saveAt(remoteFile, darwinDestFolder, fileName);
+			
 		case 'win32':
-			this._saveTmp(remoteFile, fileName, function(err, tmpPath){
-				if (err) {
-					callback(err);
-					return;
-				}
-				var ver = os.release().split('.');
-				var majorVer = 0;
+			const tmpPath = await this._saveTmp(remoteFile, fileName);
+			const ver = os.release().split('.');
+			let majorVer = 0;
 
-				if (ver.length >= 1) {
-					majorVer = parseInt(ver[0], 10);
-				}
-				if (majorVer >= 6) {
-					var ps = new PowerShell({
-						executionPolicy: 'Bypass',
-						noProfile: true
-					});
+			if (ver.length >= 1) {
+				majorVer = parseInt(ver[0], 10);
+			}
+			
+			if (majorVer >= 6) {
+				const ps = new PowerShell({
+					executionPolicy: 'Bypass',
+					noProfile: true
+				});
 
-					ps.addCommand('$fonts = (New-Object -ComObject Shell.Application).Namespace(0x14)');
-					ps.addCommand(`Get-ChildItem -Path "${tmpPath}" -Recurse -include *.ttf | % { $fonts.CopyHere($_.fullname) }`)
-					ps.invoke()
-					.then(function(output) {
-						ps.dispose();
-						callback(null, 'Font System Folder with Powershell.');
-					})
-					.catch(function(err) {
-						ps.dispose();
-						callback(err);
-					});
+				ps.addCommand('$fonts = (New-Object -ComObject Shell.Application).Namespace(0x14)');
+				ps.addCommand(`Get-ChildItem -Path "${tmpPath}" -Recurse -include *.ttf | % { $fonts.CopyHere($_.fullname) }`);
+				
+				try {
+					await ps.invoke();
+					ps.dispose();
+					return 'Font System Folder with Powershell.';
+				} catch (err) {
+					ps.dispose();
+					throw err;
 				}
-				else {
+			} else {
+				return new Promise((resolve, reject) => {
 					child_process.execFile(
 						'cscript.exe',
 						[path.join(__dirname, 'windows', 'installFont.js'), tmpPath],
-						function(err, stdout, stderr) {
-							callback(err, 'Font System Folder with cscript.');
+						(err, stdout, stderr) => {
+							if (err) reject(err);
+							else resolve('Font System Folder with cscript.');
 						}
 					);
-				}
-			})	
-			break;
+				});
+			}
+			
 		default:
-			callback(new Error('Platform not supported.'));
+			throw new Error('Platform not supported.');
 	}
-}
+};
 
 module.exports = new SystemFont();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,12 @@
       "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
-        "async": "^1.5.2",
-        "colors": "^1.1.2",
-        "commander": "^2.20.3",
+        "commander": "^12.1.0",
         "copy-paste-win32fix": "^1.4.0",
-        "file-type": "^3.6.0",
+        "file-type": "^19.6.0",
         "ink": "^6.6.0",
         "ink-select-input": "^6.2.0",
         "ink-text-input": "^6.0.0",
-        "mv": "^2.1.1",
         "ora": "^9.0.0",
         "pascal-case": "^1.1.2",
         "picocolors": "^1.1.1",
@@ -54,6 +51,28 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.1.1.tgz",
+      "integrity": "sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "7.2.0",
@@ -95,12 +114,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-      "license": "MIT"
-    },
     "node_modules/auto-bind": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
@@ -111,22 +124,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/camel-case": {
@@ -238,26 +235,14 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.1.90"
+        "node": ">=18"
       }
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
     },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
@@ -331,12 +316,21 @@
       }
     },
     "node_modules/file-type": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-      "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+      "version": "19.6.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
+      "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
       "license": "MIT",
+      "dependencies": {
+        "get-stream": "^9.0.1",
+        "strtok3": "^9.0.1",
+        "token-types": "^6.0.0",
+        "uint8array-extras": "^1.3.0"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -351,21 +345,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
       "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/has-flag": {
@@ -390,6 +383,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/indent-string": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
@@ -401,23 +414,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
     },
     "node_modules/ink": {
       "version": "6.6.0",
@@ -631,6 +627,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -686,53 +694,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mv": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "integrity": "sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==",
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "~0.5.1",
-        "ncp": "~2.0.0",
-        "rimraf": "~2.4.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -752,15 +713,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
-      "license": "MIT",
-      "bin": {
-        "ncp": "bin/ncp"
-      }
-    },
     "node_modules/node-powershell": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/node-powershell/-/node-powershell-4.0.0.tgz",
@@ -770,15 +722,6 @@
       "dependencies": {
         "chalk": "^2.4.1",
         "shortid": "^2.2.14"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -850,13 +793,17 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+    "node_modules/peek-readable": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
+      "integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/picocolors": {
@@ -904,19 +851,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-      "integrity": "sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^6.0.1"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/safer-buffer": {
@@ -1054,6 +988,23 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strtok3": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
+      "integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.3.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -1079,6 +1030,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.1.tgz",
+      "integrity": "sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.1.0",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -1086,6 +1055,18 @@
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1183,12 +1164,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.3",

--- a/package.json
+++ b/package.json
@@ -26,15 +26,12 @@
     "cli"
   ],
   "dependencies": {
-    "async": "^1.5.2",
-    "colors": "^1.1.2",
-    "commander": "^2.20.3",
+    "commander": "^12.1.0",
     "copy-paste-win32fix": "^1.4.0",
-    "file-type": "^3.6.0",
+    "file-type": "^19.6.0",
     "ink": "^6.6.0",
     "ink-select-input": "^6.2.0",
     "ink-text-input": "^6.0.0",
-    "mv": "^2.1.1",
     "ora": "^9.0.0",
     "pascal-case": "^1.1.2",
     "picocolors": "^1.1.1",


### PR DESCRIPTION
- Remove async library dependency, replace with native async/await
- Remove mv package, use native fs.promises.rename()
- Update commander v2 -> v12 (latest)
- Update file-type v3 -> v19 (latest)
- Convert all callback-based code to async/await in:
  - lib/system-font.js
  - lib/google-font.js
  - lib/google-font-list.js
  - lib/request.js
- Maintain backward compatibility with callback APIs
- Use native Array methods instead of async library
- Use fs.promises instead of callback-based fs
- Update CLI to use new Commander API

**BREAKING CHANGES:**
- Requires Node.js 14+ for fs.promises and recursive mkdir
- Commander v12 requires new Command() syntax